### PR TITLE
feat: 구독 기능 구현 및 API 연결 완료

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import Layout from "./components/Layout.tsx";
 import HomePage from "./pages/HomePage.tsx";
 import FeaturesPage from "./pages/FeaturesPage.tsx";
 import SubscriptionPage from "./pages/Subscription/SubscriptionPage.tsx";
+// import SubscriptionStatus from "./pages/Subscription/SubscriptionStatus.tsx";
 import PromotionPage from "./pages/Promotion/PromotionPage.tsx";
 import LoginPage from "./pages/Login/LoginPage.tsx";
 import RegisterPage from "./pages/Login/RegisterPage.tsx";

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import logo from "../assets/logo.png"; // ✅ 로고 불러오기
+import logo from "../assets/logo.png"; //
 
 const Navbar: React.FC = () => {
   return (
     <NavBar>
       <NavContainer>
-        {/* ✅ 로고 (왼쪽 정렬) */}
+        {/* 로고 (왼쪽 정렬) */}
         <LogoLink to="/">
           <Logo src={logo} alt="Logo" />
+          <BrandName>VITACOACH</BrandName>
         </LogoLink>
-        {/* ✅ 네비게이션 링크 (오른쪽 정렬) */}
+        {/* 네비게이션 링크 (오른쪽 정렬) */}
         <NavLinks>
           <NavItem to="/LoginPage">로그인</NavItem>
           <NavItem to="/RegisterPage">회원 가입</NavItem>
@@ -25,7 +26,7 @@ const Navbar: React.FC = () => {
 
 export default Navbar;
 
-/* ✅ Styled Components */
+/* Styled Components */
 const NavBar = styled.nav`
   position: fixed;
   top: 0;
@@ -48,6 +49,7 @@ const NavContainer = styled.div`
 const LogoLink = styled(Link)`
   display: flex;
   align-items: center;
+  text-decoration: none;
 `;
 
 const Logo = styled.img`
@@ -71,4 +73,14 @@ const NavItem = styled(Link)`
   &:focus {
     font-weight: bold;
   }
+`;
+
+const BrandName = styled.span`
+  font-size: 22px;
+  font-weight: bold;
+  color: #003f73; /* 
+  letter-spacing: 3px; /* 
+  font-family: "Arial", sans-serif;
+  text-transform: uppercase; 
+  text-decoration: none;
 `;

--- a/client/src/pages/Login/RegisterPage.tsx
+++ b/client/src/pages/Login/RegisterPage.tsx
@@ -15,12 +15,10 @@ const RegisterPage: React.FC = () => {
 
   const [error, setError] = useState("");
 
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
   };
-
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,7 +31,7 @@ const RegisterPage: React.FC = () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({...formData, birth: birthDate }),
+        body: JSON.stringify({ ...formData, birth: birthDate }),
       });
 
       if (response.status === 201) {
@@ -49,7 +47,6 @@ const RegisterPage: React.FC = () => {
       console.error("회원가입 오류:", err);
       setError("네트워크 오류가 발생했습니다.");
     }
-
   };
 
   return (
@@ -71,7 +68,6 @@ const RegisterPage: React.FC = () => {
             />
             <Icon>🆔</Icon>
           </InputWrapper>
-
 
           <Label>이름</Label>
           <InputWrapper>
@@ -116,10 +112,8 @@ const RegisterPage: React.FC = () => {
           <InputWrapper>
             <Input
               type="date"
-
               name="birth"
               value={formData.birth}
-
               onChange={handleChange}
               required
             />
@@ -130,11 +124,9 @@ const RegisterPage: React.FC = () => {
             <GenderOption>
               <input
                 type="radio"
-
                 name="sex"
                 value="WOMAN"
                 checked={formData.sex === "WOMAN"}
-
                 onChange={handleChange}
               />
               여성
@@ -142,11 +134,9 @@ const RegisterPage: React.FC = () => {
             <GenderOption>
               <input
                 type="radio"
-
                 name="sex"
                 value="MAN"
                 checked={formData.sex === "MAN"}
-
                 onChange={handleChange}
               />
               남성
@@ -155,7 +145,6 @@ const RegisterPage: React.FC = () => {
 
           <RegisterButton type="submit">가입 완료</RegisterButton>
         </Form>
-
       </RegisterBox>
     </Container>
   );
@@ -163,16 +152,12 @@ const RegisterPage: React.FC = () => {
 
 export default RegisterPage;
 
-
 const Container = styled.div`
   display: flex;
   justify-content: center;
   align-items: flex-start;
   padding-top: 10vh;
   min-height: 100vh;
-
-  background-color: #f8f9fa;
-
 `;
 
 const RegisterBox = styled.div`
@@ -182,7 +167,6 @@ const RegisterBox = styled.div`
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   width: 400px;
   text-align: center;
-
 `;
 
 const Title = styled.h2`
@@ -192,13 +176,11 @@ const Title = styled.h2`
   margin-bottom: 20px;
 `;
 
-
 const ErrorMessage = styled.p`
   color: red;
   font-size: 14px;
   margin-bottom: 10px;
 `;
-
 
 const Form = styled.form`
   display: flex;

--- a/client/src/pages/Subscription/SubscriptionPage.tsx
+++ b/client/src/pages/Subscription/SubscriptionPage.tsx
@@ -1,11 +1,26 @@
-import React from "react";
-import SubscribedPage from "./SubscribedPage.tsx";
-import UnsubscribedPage from "./UnsubscribedPage.tsx";
+import React, { useState } from "react";
+import SubscribedPage from "./SubscribedPage";
+import UnsubscribedPage from "./UnsubscribedPage";
+import SubscriptionStatus from "./SubscriptionStatus"; // ✅ 구독 상태 확인
 
-const SubscriptionPage: React.FC<{ isSubscribed: boolean }> = ({
-  isSubscribed,
-}) => {
-  return isSubscribed ? <SubscribedPage /> : <UnsubscribedPage />;
+const SubscriptionPage: React.FC = () => {
+  const [isSubscribed, setIsSubscribed] = useState<boolean | null>(null);
+
+  return (
+    <>
+      {/* ✅ 구독 상태를 가져와서 `setIsSubscribed`을 업데이트 */}
+      <SubscriptionStatus onStatusCheck={setIsSubscribed} />
+
+      {/* ✅ 구독 상태에 따라 적절한 페이지 렌더링 */}
+      {isSubscribed === null ? (
+        <p>로딩 중...</p>
+      ) : isSubscribed ? (
+        <SubscribedPage />
+      ) : (
+        <UnsubscribedPage />
+      )}
+    </>
+  );
 };
 
 export default SubscriptionPage;

--- a/client/src/pages/Subscription/SubscriptionStatus.tsx
+++ b/client/src/pages/Subscription/SubscriptionStatus.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const SubscriptionStatus: React.FC<{
+  onStatusCheck: (subscribed: boolean) => void;
+}> = ({ onStatusCheck }) => {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSubscriptionStatus = async () => {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        navigate("/LoginPage");
+        return;
+      }
+
+      try {
+        const response = await fetch("http://localhost:3000/api/sub/status", {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (response.status === 401) {
+          navigate("/LoginPage");
+          return;
+        }
+
+        const data = await response.json();
+        if (data.redirectTo === "/subscribe") {
+          onStatusCheck(false); // 구독 안 한 상태 전달
+        } else {
+          onStatusCheck(true); // 구독한 상태 전달
+        }
+      } catch (error) {
+        console.error("구독 상태 가져오는 중 오류 발생:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSubscriptionStatus();
+  }, [navigate, onStatusCheck]);
+
+  if (loading) return <p>로딩 중...</p>;
+
+  return null; // 이 컴포넌트 자체는 화면을 그리지 않음
+};
+
+export default SubscriptionStatus;

--- a/client/src/pages/Subscription/UnsubscribedPage.tsx
+++ b/client/src/pages/Subscription/UnsubscribedPage.tsx
@@ -1,19 +1,57 @@
 import React from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 
 const UnsubscribedPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  // ✅ 구독 신청 API 호출 함수
+  const handleSubscribe = async (plan: string) => {
+    const token = localStorage.getItem("token"); // ✅ 로그인 토큰 가져오기
+    if (!token) {
+      alert("로그인이 필요합니다.");
+      navigate("/LoginPage"); // ✅ 로그인 페이지로 이동
+      return;
+    }
+
+    try {
+      const response = await fetch("http://localhost:3000/api/sub/subscribe", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ plan: plan.toUpperCase() }), // ✅ 대문자로 변환하여 전달
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        alert("구독이 성공적으로 완료되었습니다!");
+        navigate("/SubscribedPage"); // ✅ 구독 완료 후 이동
+      } else {
+        alert(data.message || "구독에 실패했습니다.");
+      }
+    } catch (error) {
+      console.error("구독 요청 중 오류 발생:", error);
+      alert("서버 오류가 발생했습니다.");
+    }
+  };
+
   return (
     <Container>
       <Title>고객님께 알맞는 플랜을 고르세요!</Title>
       <PlansGrid>
-        {plans.map((plan, index) => (
-          <PlanCard key={plan.name} className={index < 2 ? "top" : "bottom"}>
+        {plans.map((plan) => (
+          <PlanCard key={plan.name}>
             <PlanTitle>{plan.name}</PlanTitle>
             <PlanDivider />
             <PlanPrice>{plan.price}</PlanPrice>
-
             <PlanPeriod>per month</PlanPeriod>
             <PlanDescription>{plan.description}</PlanDescription>
+            <SubscribeButton onClick={() => handleSubscribe(plan.name)}>
+              이 플랜 선택
+            </SubscribeButton>
           </PlanCard>
         ))}
       </PlansGrid>
@@ -36,13 +74,13 @@ const Container = styled.div`
 const Title = styled.h2`
   font-size: 32px;
   color: #2c3e50;
-  font-weight: 900; /* ✅ 훨씬 더 진하게 */
+  font-weight: 900;
   margin-bottom: 30px;
 `;
 
 const PlansGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(2, 1fr); /* ✅ 2열 정렬 (2개 + 2개) */
+  grid-template-columns: repeat(2, 1fr);
   gap: 25px;
   justify-content: center;
 `;
@@ -53,9 +91,7 @@ const PlanCard = styled.div`
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   padding: 25px;
   text-align: center;
-  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
   border: 2px solid transparent;
-
   &:hover {
     transform: scale(1.07);
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
@@ -90,13 +126,31 @@ const PlanDescription = styled.p`
   line-height: 1.6;
   white-space: pre-line;
 `;
+
 const PlanDivider = styled.div`
   width: 50%;
   height: 1px;
-  background-color: #ddd; /* ✅ 연한 회색 구분선 */
-  margin: 10px auto; /* ✅ 중앙 정렬 */
+  background-color: #ddd;
+  margin: 10px auto;
 `;
 
+const SubscribeButton = styled.button`
+  background-color: #0669ba;
+  color: white;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-top: 15px;
+
+  &:hover {
+    background-color: #004a85;
+  }
+`;
+
+// ✅ 구독 가능한 플랜 목록
 const plans = [
   {
     name: "Bronze",


### PR DESCRIPTION
## 📝 Part
- [x] FE
- [ ] BE

## ✨ 변경 사항
- 구독 기능 (`UnsubscribedPage.tsx`)에 백엔드 API (`POST /sub/subscribe`) 연결
- 구독 요청 시 `plan` 값을 대문자로 변환하여 백엔드에 전송 (ex: "BRONZE", "PLATINUM")
- 구독 완료 후 `SubscribedPage`로 자동 이동 (`navigate("/SubscribedPage")`)
- 로그인 여부 확인 후, 로그인하지 않은 경우 `/LoginPage`로 리디렉션
- API 호출 시 JWT 토큰을 `Authorization` 헤더에 포함하여 인증 처리


## ✅ 체크리스트
- [ ] API 정상 동작 확인  
- [ ] 에러 핸들링 테스트  

## 전달 사항
- 전달이 필요한 부분을 적어주세요
